### PR TITLE
Eliminate dependence on Python-LibUnicodeNames.

### DIFF
--- a/fontaine/builder.py
+++ b/fontaine/builder.py
@@ -14,14 +14,9 @@ import csv
 import os
 import StringIO
 import sys
+import unicodedata
 
 from collections import OrderedDict
-
-try:
-    from unicodenames import unicodenames
-    os.environ['UNAMES_INSTALLED'] = 'uname-installed'
-except ImportError:
-    pass
 
 
 from fontaine.const import SUPPORT_LEVEL_FULL, SUPPORT_LEVEL_UNSUPPORTED
@@ -40,13 +35,11 @@ db = os.environ.get('UNAMES_DB') or os.path.join(os.path.dirname(__file__),
 
 def format(x):
     return u'U+%04x\x20\x20%s\x20\x20%s' % \
-        (x, unichr(x), unicodenames(db).name(x) or '')
-
+        (x, unichr(x), unicodedata.name(unichr(x), ''))
 
 def unicodevalues_asstring(values):
-    """ Return string with unicodenames if db defined """
-    if os.environ.get('UNAMES_INSTALLED') \
-            and not os.environ.get('DISABLE_UNAMES'):
+    """ Return string with unicodenames (unless that is disabled) """
+    if not os.environ.get('DISABLE_UNAMES'):
         return map(lambda x: '%s' % format(x).strip(), values)
     return map(lambda x: u'U+%04x %s' % (x, unichr(x)), values)
 

--- a/fontaine/main.py
+++ b/fontaine/main.py
@@ -28,7 +28,7 @@ def usage():
     parser = argparse.ArgumentParser(description='Output information about fonts in different formats')
     parser.add_argument('font', metavar='font', type=str, nargs='+')
     parser.add_argument('--disable-unames', action='store_true',
-                        help='If libunicodenames is installed this will prevent using it')
+                        help='This will prevent using Unicode names data')
     parser.add_argument('--text', action='store_true',
                         help='Output information in plain text')
     parser.add_argument('--xml', action='store_true',
@@ -62,10 +62,6 @@ def main(*argv):
     else:
         tree = director.construct_tree(fonts)
         Builder.text_(tree).display()
-
-    if not os.environ.get('UNAMES_INSTALLED'):
-        print('Warning: package `libunicodenames` is not installed',
-              file=sys.stderr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is just using the standard Python 2.7 library’s ‘unicodedata’ module.
