### PR TITLE
Added tabulate project dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,9 @@ It has a straightforward pythonic set definition format:
 - `medium example <https://github.com/davelab6/pyfontaine/blob/master/fontaine/charsets/internals/armenian.py>`__
 - `complex example <https://github.com/davelab6/pyfontaine/blob/master/fontaine/charsets/internals/polish.py>`__
 
-Additional definitions are downloaded from the Extensis, font-config and Unicode websites during installation, and can be updated without reinstalling. 
+Additional definitions are downloaded from the Extensis, font-config and Unicode websites during installation, and can be updated without reinstalling.
 
-Adding your own definitions is easy. 
+Adding your own definitions is easy.
 All files in the `internals <https://github.com/davelab6/pyfontaine/tree/master/fontaine/charsets/internals>`__ directory are auto-detected, so just add definition files there.
 
 Installation
@@ -79,8 +79,8 @@ To print a list of all the missing unicode values from each set::
 
     pyfontaine --missing --set adobe_latin_3 font.ttf;
 
-.. To output visualisations of the coverage using `Hilbert curves <http://en.wikipedia.org/wiki/Hilbert_curve>`__ (thanks for the idea, `Øyvind 'pippin' Kolås <http://github.com/hodefoting>`__!): 
-.. 
+.. To output visualisations of the coverage using `Hilbert curves <http://en.wikipedia.org/wiki/Hilbert_curve>`__ (thanks for the idea, `Øyvind 'pippin' Kolås <http://github.com/hodefoting>`__!):
+..
 ..    pyfontaine --coverage font.ttf; ls -l coverage_pngs/;
 ..
 .. The PNG files are stored in a new directory, ``coverage_pngs``, under the current directory.
@@ -120,15 +120,15 @@ Thanks
 ------
 
 We would like to thank some upstream projects that make pyfontaine even
-more useful: 
+more useful:
 
 * `Thomas Phinney <http://www.thomasphinney.com/>`__ for the `WebINK Character
   Sets <http://blog.webink.com/custom-font-subsetting-for-faster-websites/>`__
 
 * `Behdad Esfabod <http://behdad.org>`__ for the `font-config languages
-  definitions <http://cgit.freedesktop.org/fontconfig/tree/fc-lang>`__ 
+  definitions <http://cgit.freedesktop.org/fontconfig/tree/fc-lang>`__
 
-* Unicode Consortium for the `Unicode Blocks 
+* Unicode Consortium for the `Unicode Blocks
   <http://www.unicode.org/Public/UNIDATA/Blocks.txt>`__
 
 Dependencies
@@ -141,6 +141,7 @@ Dependencies
 - `PyICU <http://pyicu.osafoundation.org/>`__
 - `simpleHilbertCurve <https://github.com/dentearl/simpleHilbertCurve>`__
 - `matplotlib <https://pypi.python.org/pypi/matplotlib>`__
+- `tabulate <https://pypi.python.org/pypi/tabulate>`__
 
 Related Projects
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(name='fontaine',
       packages=['fontaine', 'fontaine.charsets', 'fontaine.charsets.internals', 'fontaine.structures', 'fontaine.ext'],
       install_requires=[
           'lxml',
-          'requests'
+          'requests',
+          'tabulate'
       ],
       dependency_links=['https://github.com/behdad/fontTools/tarball/master#egg=fontTools-2.4'],
       package_data={


### PR DESCRIPTION
Following install from PyPI after installation of the project dependencies listed on the README file, `pyfontaine` call from the command line fails for me because of missing `tabulate` module added in this commit:

https://github.com/davelab6/pyfontaine/commit/6c54e32b4c2c01524f78d352ec1b96643a2aaf82#diff-634231f3fccdd7853307d6e9cdbf69e6R31

This PR adds `tabulate` to the README dependency list and to the setup.py file as a project dependency.