### PR TITLE
Fix Non-ASCII character error

### DIFF
--- a/fontaine/ext/fontconfig.py
+++ b/fontaine/ext/fontconfig.py
@@ -56,7 +56,7 @@ class Extension(BaseExt):
         #     ''
         # }
 
-        common_name_regex = re.compile(u'#\s+([åíá,\s\(\)\'\w/-]+)\s*\(([\w_-]{2,6})\)', re.I | re.U | re.S)
+        common_name_regex = re.compile(u'#\s+([\u00E5\u00ED\u00E1,\s\(\)\'\w/-]+)\s*\(([\w_-]{2,6})\)', re.I | re.U | re.S)
 
         content = content.replace('# Chinese (traditional) ZH-TW', '# Chinese traditional (ZH-TW)')
 


### PR DESCRIPTION
    SyntaxError: Non-ASCII character '\xc3' in file /pyfontaine/fontaine/ext/fontconfig.py on line 59, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details