### PR TITLE
Explicitly label README as UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 
 from setuptools import setup
 
-with open("README.rst", 'r') as readme_file:
+with open("README.rst", 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 from fontaine import VERSION

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@
 # See accompanying LICENSE.txt file for details.
 
 from setuptools import setup
+from io import open
 
 with open("README.rst", 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
On some machines (e.g. by default in many Docker images), the locale
will cause setuptools to assume ASCII text by default. This causes a
UnicodeDecodeError when trying to parse the README.rst for installation.
Fix this by explicitly labeling the README as UTF-8 prior to reading it.