### PR TITLE
use 'as' to label exception

### DIFF
--- a/fontaine/cmap.py
+++ b/fontaine/cmap.py
@@ -53,7 +53,7 @@ class Library(object):
                 try:
                     module = import_module('fontaine.charsets.internals.%s' % ext)
                     self.register(module.Charset)
-                except (ImportError, AttributeError), ex:
+                except (ImportError, AttributeError) as ex:
                     continue
         return self._charsets
 


### PR DESCRIPTION
For Python 3.x, exceptions should be assigned with the 'as' keyword. See
PEP3110 for details, this syntax is supported in Python 2.6+.